### PR TITLE
Fix "instance undefined" warning

### DIFF
--- a/tasks/connect.js
+++ b/tasks/connect.js
@@ -202,10 +202,10 @@ module.exports = function(grunt) {
                 grunt.fatal(err);
               }
             });
-        });
 
-        grunt.config('connect.' + taskTarget + '.server-closer', function(cb) {
-          instance.close(cb);
+          grunt.config('connect.' + taskTarget + '.server-closer', function(cb) {
+            instance.close(cb);
+          });
         });
 
         // So many people expect this task to keep alive that I'm adding an option


### PR DESCRIPTION
At least on node v0.12.7 calling disconnect stops grunt with "Warning: instance is not defined Use --force to continue." With --force, connect server is not stopped.

This patch fixes the issue by moving server closer function creation to the proper block.
